### PR TITLE
Fix symlink path inside deb build script

### DIFF
--- a/deb/build
+++ b/deb/build
@@ -87,6 +87,6 @@ fpm -f -s dir -t deb -n "$pkgname" -v "$pkgversion" \
 	--depends "libebtree$libversion (=$pkgversion)" \
 	--deb-changelog "$changelog" \
 	../libebtree.a=/usr/lib/libebtree.a \
-	./libebtree.so=/usr/lib/libebtree.so \
+	./libebtree.so=/usr/lib/ \ # Was =/usr/lib/libebtree.so, see XXX comment above
 	./ebtree=/usr/include
 


### PR DESCRIPTION
For symlinks, the fpm syntax is following

source-link=/destination-dir

So

./libebtree.so=/usr/lib/libebtree.so

will place libebtree.so symlink **inside** /usr/lib/libebtree.so
**directory** which is wrong - it should be inside /usr/lib
directory.

This prevented users of `libebtree-dev` to link against dynamic library.