### PR TITLE
pkg: Dependencies are missing the epoch specification in the version

### DIFF
--- a/deb/build
+++ b/deb/build
@@ -87,7 +87,7 @@ fpm -f -s dir -t deb -n "$pkgname" -v "$pkgversion" \
 	--vendor 'Sociomantic Labs GmbH' \
 	--license MIT \
 	--category libdevel \
-	--depends "libebtree$libversion (=$pkgversion)" \
+	--depends "libebtree$libversion (=$epoch:$pkgversion)" \
 	--deb-changelog "$changelog" \
 	--epoch "$epoch" \
 	../libebtree.a=/usr/lib/libebtree.a \


### PR DESCRIPTION
Currently I have the following ebtree packages installed on my system:

```
$ dpkg -l | grep libebtree
ii  libebtree6                                 6.0.socio6-xenial                            amd64        Elastic Binary Tree library
ii  libebtree6-dev                             6.0.socio6-xenial                            amd64        Elastic Binary Tree library (development files)
```

`apt` wants to upgrade `libebtree6` but cannot do so without uninstalling `libebtree6-dev`.  Looking at the latest package versions and dependencies one finds the following:

```
Package: libebtree6
Version: 1:6.0.socio7-xenial
```

```
Package: libebtree6-dev
Version: 1:6.0.socio7-xenial
Depends: libebtree6 (=6.0.socio7-xenial)
```

... i.e. the package version numbers now include an "epoch" (the `1:`), to use the Debian terminology, but this is not present in the `Depends:` conditions of `libebtree6-dev`.  I suspect that this means that apt cannot resolve the dependency.