### PR TITLE
Update to latest develbase cachalot image

### DIFF
--- a/beaver.Dockerfile
+++ b/beaver.Dockerfile
@@ -1,1 +1,1 @@
-FROM sociomantictsunami/develbase:v6
+FROM sociomantictsunami/develbase:v8


### PR DESCRIPTION
The new cachalot docker image is available for Ubuntu
xenial and bionic distributions and includes improvements
and bug fixes.